### PR TITLE
Separate exception classes to their own files

### DIFF
--- a/src/AdamStipak/Webpay/Api.php
+++ b/src/AdamStipak/Webpay/Api.php
@@ -76,7 +76,3 @@ class Api {
     }
   }
 }
-
-class Exception extends \Exception {
-
-}

--- a/src/AdamStipak/Webpay/Exception.php
+++ b/src/AdamStipak/Webpay/Exception.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace AdamStipak\Webpay;
+
+class Exception extends \Exception {
+
+}

--- a/src/AdamStipak/Webpay/PaymentResponse.php
+++ b/src/AdamStipak/Webpay/PaymentResponse.php
@@ -2,8 +2,6 @@
 
 namespace AdamStipak\Webpay;
 
-use AdamStipak\Webpay\Exception;
-
 class PaymentResponse {
 
   /** @var array */
@@ -64,35 +62,5 @@ class PaymentResponse {
    */
   public function getDigest1() {
     return $this->digest1;
-  }
-}
-
-class PaymentResponseException extends Exception {
-
-  /** @var int */
-  private $prCode;
-
-  /** @var int */
-  private $srCode;
-
-  public function __construct ($prCode, $srCode = 0, $message = "", Exception $previous = null) {
-    $this->prCode = $prCode;
-    $this->srCode = $srCode;
-
-    parent::__construct($message, $prCode, $previous);
-  }
-
-  /**
-   * @return int
-   */
-  public function getPrCode () {
-    return $this->prCode;
-  }
-
-  /**
-   * @return int
-   */
-  public function getSrCode () {
-    return $this->srCode;
   }
 }

--- a/src/AdamStipak/Webpay/PaymentResponse.php
+++ b/src/AdamStipak/Webpay/PaymentResponse.php
@@ -2,7 +2,7 @@
 
 namespace AdamStipak\Webpay;
 
-use Exception;
+use AdamStipak\Webpay\Exception;
 
 class PaymentResponse {
 

--- a/src/AdamStipak/Webpay/PaymentResponseException.php
+++ b/src/AdamStipak/Webpay/PaymentResponseException.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace AdamStipak\Webpay;
+
+class PaymentResponseException extends Exception {
+
+  /** @var int */
+  private $prCode;
+
+  /** @var int */
+  private $srCode;
+
+  public function __construct ($prCode, $srCode = 0, $message = "", Exception $previous = null) {
+    $this->prCode = $prCode;
+    $this->srCode = $srCode;
+
+    parent::__construct($message, $prCode, $previous);
+  }
+
+  /**
+   * @return int
+   */
+  public function getPrCode () {
+    return $this->prCode;
+  }
+
+  /**
+   * @return int
+   */
+  public function getSrCode () {
+    return $this->srCode;
+  }
+}


### PR DESCRIPTION
Original text is below but in the end I solved the situation (which I believe is a server-side issue) in a different way - by separating exception classes to their own files.

~~I can't figure out why, but my server (PHP 5.6.13) fails to use the class (literally nothing happens - the execution is terminated when I try to interact with the PaymentResponse class in any way) without full namespace to the Exception class. This fixed it and it shouldn't break anything as it is the same written in a different way.~~
