### PR TITLE
Normalize boolean params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor/*
+.idea/*

--- a/src/AdamStipak/Webpay/PaymentRequest.php
+++ b/src/AdamStipak/Webpay/PaymentRequest.php
@@ -49,6 +49,12 @@ class PaymentRequest {
    * @return array
    */
   public function getParams () {
+    foreach ($this->params as $key => $param) {
+      if ($param === false) {
+        $this->params[$key] = 0;
+      }
+    }
+
     return $this->params;
   }
 

--- a/src/AdamStipak/Webpay/Signer.php
+++ b/src/AdamStipak/Webpay/Signer.php
@@ -56,7 +56,7 @@ class Signer {
    * @return string
    */
   public function sign(array $params) {
-    $this->normalizeParams($params);
+    $params = $this->normalizeParams($params);
     $digestText = implode('|', $params);
     openssl_sign($digestText, $digest, $this->getPrivateKeyResource());
     $digest = base64_encode($digest);

--- a/src/AdamStipak/Webpay/Signer.php
+++ b/src/AdamStipak/Webpay/Signer.php
@@ -56,7 +56,6 @@ class Signer {
    * @return string
    */
   public function sign (array $params) {
-    $params = $this->normalizeParams($params);
     $digestText = implode('|', $params);
     openssl_sign($digestText, $digest, $this->getPrivateKeyResource());
     $digest = base64_encode($digest);
@@ -98,21 +97,5 @@ class Signer {
     }
 
     return $this->publicKeyResource;
-  }
-
-  /**
-   * Normalize array of parameters for valid use in implode function
-   *
-   * @param array $params
-   * @return array
-   */
-  private function normalizeParams($params) {
-    foreach ($params as $key => $param) {
-      if ($param === false) {
-        $params[$key] = 0;
-      }
-    }
-
-    return $params;
   }
 }

--- a/src/AdamStipak/Webpay/Signer.php
+++ b/src/AdamStipak/Webpay/Signer.php
@@ -70,7 +70,6 @@ class Signer {
    * @throws SignerException
    */
   public function verify (array $params, $digest) {
-    $params = $this->normalizeParams($params);
     $data = implode('|', $params);
     $digest = base64_decode($digest);
 

--- a/src/AdamStipak/Webpay/Signer.php
+++ b/src/AdamStipak/Webpay/Signer.php
@@ -56,6 +56,7 @@ class Signer {
    * @return string
    */
   public function sign(array $params) {
+    $this->normalizeParams($params);
     $digestText = implode('|', $params);
     openssl_sign($digestText, $digest, $this->getPrivateKeyResource());
     $digest = base64_encode($digest);
@@ -69,6 +70,7 @@ class Signer {
    * @throws SignerException
    */
   public function verify(array $params, $digest) {
+    $params = $this->normalizeParams($params);
     $data = implode('|', $params);
     $digest = base64_decode($digest);
 
@@ -97,5 +99,21 @@ class Signer {
     }
 
     return $this->publicKeyResource;
+  }
+
+  /**
+   * Normalize array of parameters for valid use in implode function
+   *
+   * @param array $params
+   * @return array
+   */
+  private function normalizeParams($params) {
+    foreach ($params as $key => $param) {
+      if ($param === false) {
+        $params[$key] = 0;
+      }
+    }
+
+    return $params;
   }
 }


### PR DESCRIPTION
This PR fixes calculating wrong digest when `DEPOSITFLAG` or other parameters (contained in digest), that have value of boolean, are set to `false`.

According to GP webpay documentation, there is parameter called `DEPOSITFLAG`, that is contained in digest, which is used to verify the request. This parameter has values of boolean type. Problem occures, when `DEPOSITFLAG` parameter is set to `false`, because all parameters are represented as associative array and function implode is called on this array.

In [PHP documentation](http://php.net/manual/fr/function.implode.php#104568) there is confirmed, that implode "called" on array item, that contains `false` does nothing. This leads to following situation in `PaymentRequest`:

- `DEPOSITFLAG` in query string is correctly set to `0`
- `DIGEST` is calculated with empty string as `DEPOSITFLAG`.

The obvious result is that GP webpay denies your request.

I would be really thankful if you merge this pull request and publish new version to packagist, because in my opinion there is no reason to create new fork just because of little bug. 