### PR TITLE
Get correct constant for currency in PaymentRequest

### DIFF
--- a/src/AdamStipak/Webpay/PaymentRequest.php
+++ b/src/AdamStipak/Webpay/PaymentRequest.php
@@ -28,7 +28,7 @@ class PaymentRequest {
     $this->params['OPERATION'] = 'CREATE_ORDER';
     $this->params['ORDERNUMBER'] = $orderNumber;
     $this->params['AMOUNT'] = $amount * 100;
-    $this->params['CURRENCY'] = $currency;
+    $this->params['CURRENCY'] = constant('self::'. $currency);
     $this->params['DEPOSITFLAG'] = $depositFlag;
 
     if ($merOrderNumber) {


### PR DESCRIPTION
Hi Adam, firstly thank you for your work on this package.

I think that I have found an bug. Because you are defining constants of currencies in PaymentRequest.php and in the end not using them anywhere. Also you are excepting to $currency come as string. But In the end It should be integer representation of country code. 