### PR TITLE
Add support for PAYMETHOD parameter

### DIFF
--- a/src/AdamStipak/Webpay/PaymentRequest.php
+++ b/src/AdamStipak/Webpay/PaymentRequest.php
@@ -39,7 +39,8 @@ class PaymentRequest {
     string $url,
     string $merOrderNumber = null,
     string $md = null,
-    AddInfo $addInfo = null
+    AddInfo $addInfo = null,
+    string $paymentMethod = 'CRD'
   ) {
     $this->params['MERCHANTNUMBER'] = "";
     $this->params['OPERATION'] = 'CREATE_ORDER';
@@ -53,6 +54,7 @@ class PaymentRequest {
     }
 
     $this->params['URL'] = $url;
+    $this->params['PAYMETHOD'] = $paymentMethod;
 
     if ($md !== null) {
       $this->params['MD'] = $md;

--- a/src/AdamStipak/Webpay/PaymentRequest.php
+++ b/src/AdamStipak/Webpay/PaymentRequest.php
@@ -3,6 +3,7 @@
 namespace AdamStipak\Webpay;
 
 use AdamStipak\Webpay\PaymentRequest\AddInfo;
+use AdamStipak\Webpay\PaymentRequest\PaymentMethod;
 
 /**
  * Payment Requester class
@@ -16,6 +17,16 @@ class PaymentRequest {
   const PLN = 985;
   const RUB = 643;
   const USD = 840;
+
+  const APPLE_PAY = 'APAY';
+  const EPS = 'EPS';
+  const GOOGLE_PAY = 'GPAY';
+  const KLARNA = 'KLARNA';
+  const PAYMENT_CARD = 'CRD';
+  const PAYSAFECARD = 'PAYSAFECARD';
+  const PLATBA_24 = 'BTNCS';
+  const SEPADIRECTDEBIT = 'SEPADIRECTDEBIT';
+  const SOFORT = 'SOFORT';
 
   /** @var array */
   private $params = [];
@@ -40,7 +51,7 @@ class PaymentRequest {
     string $merOrderNumber = null,
     string $md = null,
     AddInfo $addInfo = null,
-    string $paymentMethod = 'CRD'
+    string $paymentMethod = self::PAYMENT_CARD
   ) {
     $this->params['MERCHANTNUMBER'] = "";
     $this->params['OPERATION'] = 'CREATE_ORDER';

--- a/src/AdamStipak/Webpay/PaymentRequest.php
+++ b/src/AdamStipak/Webpay/PaymentRequest.php
@@ -3,7 +3,6 @@
 namespace AdamStipak\Webpay;
 
 use AdamStipak\Webpay\PaymentRequest\AddInfo;
-use AdamStipak\Webpay\PaymentRequest\PaymentMethod;
 
 /**
  * Payment Requester class


### PR DESCRIPTION
Allow to set different payment method (https://www.gpwebpay.cz/downloads/GP_webpay_HTTP_EN.pdf):
```
CRD – payment card
GPAY – GooglePay
APAY – Apple Pay
BTNCS – Platba 24
SOFORT
EPS
PAYSAFECARD
SEPADIRECTDEBIT
KLARNA
```