### PR TITLE
Update PaymentResponse.php

### DIFF
--- a/src/AdamStipak/Webpay/PaymentResponse.php
+++ b/src/AdamStipak/Webpay/PaymentResponse.php
@@ -23,7 +23,7 @@ class PaymentResponse {
    * @param string $digest
    * @param string $digest1
    */
-  public function __construct (string $operation, string $ordernumber, string $merordernum = null, int $prcode, int $srcode, string $resulttext, string $digest, string $digest1, string $md = null) {
+  public function __construct (string $operation, string $ordernumber, string $merordernum = null, int $prcode, int $srcode, string $resulttext = null, string $digest, string $digest1, string $md = null) {
     $this->params['operation'] = $operation;
     $this->params['ordermumber'] = $ordernumber;
     if ($merordernum !== null) {
@@ -34,7 +34,12 @@ class PaymentResponse {
     }
     $this->params['prcode'] = $prcode;
     $this->params['srcode'] = $srcode;
-    $this->params['resulttext'] = $resulttext;
+    if($resulttext !== null){
+      $this->params['resulttext'] = $resulttext;
+    }
+    
+
+    
     $this->digest = $digest;
     $this->digest1 = $digest1;
   }


### PR DESCRIPTION
I was stuck at verifying DIGEST from sandbox for two hours, when Google Pay was chosen. I have tested it in sandbox mode and concluded, that digest cannot be verified correctly, if Google pay is chosen as payment method, because GPWebPay doesn't return RESULTTEXT in the query string in this scenario (at least in sandbox mode). This change shouldn't break existing projects and can be less confusing for other devs, so they check if the resulttext is present before putting it into the parameter.